### PR TITLE
Cleaned up C# interop

### DIFF
--- a/native/logik_simulation/src/ffi.rs
+++ b/native/logik_simulation/src/ffi.rs
@@ -36,21 +36,21 @@ pub extern "C" fn exit(data: *mut Data) {
 }
 
 #[no_mangle]
-pub extern "C" fn add_subnet(data: *mut Data, id: usize) -> bool {
+pub extern "C" fn add_subnet(data: *mut Data, id: i32) -> bool {
     let data = unsafe { &mut *data};
     
-    data.add_subnet(id)
+    data.add_subnet(id as usize)
 }
 
 #[no_mangle]
-pub extern "C" fn remove_subnet(data: *mut Data, id: usize) -> bool {
+pub extern "C" fn remove_subnet(data: *mut Data, id: i32) -> bool {
     let data = unsafe { &mut *data};
     
-    data.remove_subnet(id)
+    data.remove_subnet(id as usize)
 }
 
 #[no_mangle]
-pub extern "C" fn add_component(data: *mut Data, component: usize) -> usize {
+pub extern "C" fn add_component(data: *mut Data, component: i32) -> i32 {
     let data = unsafe { &mut *data};
     
     let component: Box<dyn Component> = match component {
@@ -65,26 +65,26 @@ pub extern "C" fn add_component(data: *mut Data, component: usize) -> usize {
                        iter::repeat(None).take(i).collect(),
                        iter::repeat(None).take(o).collect());
     
-    res.unwrap()
+    res.unwrap() as i32
 }
 
 #[no_mangle]
-pub extern "C" fn remove_component(data: *mut Data, id: usize) -> bool {
+pub extern "C" fn remove_component(data: *mut Data, id: i32) -> bool {
     let data = unsafe { &mut *data };
     
-    data.remove_component(id)
+    data.remove_component(id as usize)
 }
 
 #[no_mangle]
-pub extern "C" fn link(data: *mut Data, component: usize, port: usize, subnet: usize, direction: bool) -> bool {
+pub extern "C" fn link(data: *mut Data, component: usize, port: i32, subnet: i32, direction: bool) -> bool {
     let data = unsafe { &mut *data };
     
-    data.link(component, port, subnet, direction)
+    data.link(component, port as usize, subnet as usize, direction)
 }
 
 #[no_mangle]
-pub extern "C" fn unlink(data: *mut Data, component: usize, port: usize, subnet: usize) -> bool {
+pub extern "C" fn unlink(data: *mut Data, component: i32, port: i32, subnet: i32) -> bool {
     let data = unsafe { &mut *data };
     
-    data.unlink(component, port, subnet)
+    data.unlink(component as usize, port as usize, subnet as usize)
 }

--- a/src/LogikUI/Circuit/Gates.cs
+++ b/src/LogikUI/Circuit/Gates.cs
@@ -68,24 +68,20 @@ namespace LogikUI.Circuit
 
         public void ApplyTransaction(GateTransaction transaction)
         {
-            UIntPtr id;
-            unsafe
-            {
-                id = Logic.AddComponent(Program.backend, new UIntPtr((uint) transaction.Created.Type));
-            }
-            transaction.Created.ID = (int) id;
+            transaction.Created.ID = Logic.AddComponent(Program.Backend, transaction.Created.Type);
             Instances.Add(transaction.Created);
         }
 
         public void RevertTransaction(GateTransaction transaction)
         {
-            unsafe
+            if (transaction.Created.ID == 0)
+                throw new InvalidOperationException("Cannot revert a transaction where the gates doesn't have a valid id! (Maybe you forgot to apply the transaction before?)");
+
+            if (Logic.RemoveComponent(Program.Backend, transaction.Created.ID) == false)
             {
-                if (transaction.Created.ID >= 0)
-                {
-                    Logic.RemoveComponent(Program.backend, new UIntPtr((uint) transaction.Created.ID));
-                }
+                Console.WriteLine($"Warn: Rust said we couldn't remove this gate id: {transaction.Created.ID}. ({transaction.Created})");
             }
+
             if (Instances.Remove(transaction.Created) == false)
             {
                 Console.WriteLine($"Warn: Removed non-existent gate! {transaction.Created}");

--- a/src/LogikUI/Interop/Logic.cs
+++ b/src/LogikUI/Interop/Logic.cs
@@ -1,6 +1,8 @@
-﻿using System;
+﻿using LogikUI.Simulation.Gates;
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -9,64 +11,37 @@ namespace LogikUI.Interop
 {
     static class Logic
     {
-#if WINDOWS
-        const string Lib = "Native/logik_simulation";
-#else
-        const string Lib = "Native/liblogik_simulation";
-#endif
+        const string Lib = "logik_simulation";
+
         const CallingConvention CallingConv = CallingConvention.Cdecl;
 
         [DllImport(Lib, EntryPoint = "init", ExactSpelling = true, CallingConvention = CallingConv)]
-        public static extern unsafe Data* Init();
+        public static extern Data Init();
 
         [DllImport(Lib, EntryPoint = "exit", ExactSpelling = true, CallingConvention = CallingConv)]
-        public static extern unsafe void Exit(Data* data);
+        public static extern void Exit(Data data);
         
         [DllImport(Lib, EntryPoint = "add_subnet", ExactSpelling = true, CallingConvention = CallingConv)]
-        public static extern unsafe bool AddSubnet(Data* data, UIntPtr id);
+        public static extern bool AddSubnet(Data data, int subnetId);
         
         [DllImport(Lib, EntryPoint = "remove_subnet", ExactSpelling = true, CallingConvention = CallingConv)]
-        public static extern unsafe bool RemoveSubnet(Data* data, UIntPtr id);
+        public static extern bool RemoveSubnet(Data data, int subnetId);
         
         [DllImport(Lib, EntryPoint = "add_component", ExactSpelling = true, CallingConvention = CallingConv)]
-        public static extern unsafe UIntPtr AddComponent(Data* data, UIntPtr component);
+        public static extern int AddComponent(Data data, ComponentType componentType);
         
         [DllImport(Lib, EntryPoint = "remove_component", ExactSpelling = true, CallingConvention = CallingConv)]
-        public static extern unsafe bool RemoveComponent(Data* data, UIntPtr id);
+        public static extern bool RemoveComponent(Data data, int componentId);
         
         [DllImport(Lib, EntryPoint = "link", ExactSpelling = true, CallingConvention = CallingConv)]
-        public static extern unsafe void Link(Data* data, UIntPtr component, UIntPtr port, UIntPtr subnet, bool direction);
+        public static extern void Link(Data data, int componentId, int port, int subnetId, bool direction);
         
         [DllImport(Lib, EntryPoint = "unlink", ExactSpelling = true, CallingConvention = CallingConv)]
-        public static extern unsafe void Unlink(Data* data, UIntPtr component, UIntPtr port, UIntPtr subnet);
-
-        // --------------------------
-        // ---- Interop examples ----
-        // --------------------------
-
-        [DllImport(Lib, EntryPoint = "test", ExactSpelling = true, CallingConvention = CallingConv)]
-        public static extern void Test();
-
-        [DllImport(Lib, EntryPoint = "test2", ExactSpelling = true, CallingConvention = CallingConv)]
-        public static extern void Test2(int i);
-
-        [DllImport(Lib, EntryPoint = "add", ExactSpelling = true, CallingConvention = CallingConv)]
-        public static extern int Add(int a, int b);
-
-        [DllImport(Lib, EntryPoint = "do_cool_stuff", ExactSpelling = true, CallingConvention = CallingConv)]
-        public static extern void DoCoolStuff(ref CoolStruct stuff);
-
-        [StructLayout(LayoutKind.Sequential)]
-        public struct CoolStruct
-        {
-            public int ID;
-            [MarshalAs(UnmanagedType.LPUTF8Str)]
-            public string ThisIsAnInterestingThing;
-        }
+        public static extern void Unlink(Data data, int componentId, int port, int subnetId);
     }
 
     public struct Data
     {
-        
+        public IntPtr Handle;
     }
 }

--- a/src/LogikUI/LogikUI.csproj
+++ b/src/LogikUI/LogikUI.csproj
@@ -40,16 +40,4 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(NativeRid)' == 'win-x64' Or ('$(NativeRid)' == '' And '$([MSBuild]::IsOsPlatform(`WINDOWS`))' == 'true') ">
-    <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(NativeRid)' == 'linux-x64' Or ('$(NativeRid)' == '' And '$([MSBuild]::IsOsPlatform(`LINUX`))' == 'true') ">
-    <DefineConstants>$(DefineConstants);LINUX;UNIX</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(NativeRid)' == 'osx-x64'  Or ('$(NativeRid)' == '' And '$([MSBuild]::IsOsPlatform(`OSX`))' == 'true') ">
-    <DefineConstants>$(DefineConstants);MACOS;UNIX</DefineConstants>
-  </PropertyGroup>
 </Project>

--- a/src/LogikUI/Program.cs
+++ b/src/LogikUI/Program.cs
@@ -18,7 +18,7 @@ namespace LogikUI
 {
     class Program
     {
-        public static unsafe Data* backend;
+        public static Data Backend;
         
         static Gtk.Toolbar CreateToolbar(CircuitEditor editor) {
             Gtk.Toolbar toolbar = new Gtk.Toolbar();
@@ -79,10 +79,7 @@ namespace LogikUI
         // Hopefully this can be fixed sooner rather than later...
         static void Main()
         {
-            unsafe
-            {
-                Program.backend = Logic.Init();
-            }
+            Backend = Logic.Init();
             
             CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
 
@@ -162,11 +159,7 @@ namespace LogikUI
 
         private static void Wnd_Destroyed(object? sender, EventArgs e)
         {
-            unsafe
-            {
-                Logic.Exit(Program.backend);
-                Program.backend = null;
-            }
+            Logic.Exit(Backend);
             Application.Quit();
         }
     }

--- a/src/Native.targets
+++ b/src/Native.targets
@@ -107,10 +107,10 @@
     <!-- FIXME: Make sure to copy the .pdb file if there is one, that way debugging can work with much less effort -->
     <!-- FIXME: Move the built library into its correct platform folder so that it's correctly picked up by DllImport -->
     <Target Name="CargoBuildCopy" DependsOnTargets="Cargo" AfterTargets="Build" Condition=" '$(IsAotBuild)' == 'false' ">
-        <Copy Condition=" '$(TargetDir)' != '' " SourceFiles="@(CargoLibrary)" DestinationFolder="$(TargetDir)/Native" />
+        <Copy Condition=" '$(TargetDir)' != '' " SourceFiles="@(CargoLibrary)" DestinationFolder="$(TargetDir)" />
     </Target>
 
     <Target Name="CargoPublishCopy" DependsOnTargets="Cargo" AfterTargets="Publish" Condition=" '$(IsAotBuild)' == 'false' ">
-        <Copy SourceFiles="@(CargoLibrary)" DestinationFolder="$(PublishDir)/Native" />
+        <Copy SourceFiles="@(CargoLibrary)" DestinationFolder="$(PublishDir)" />
     </Target>
 </Project>


### PR DESCRIPTION
This pr cleans up the C# interop a bit so we don't have to use unsafe and makes the types used for interop fixed size (not dependent on platform).