### PR TITLE
Rework of edge storing

### DIFF
--- a/native/logik_simulation/src/data/component/statefuls.rs
+++ b/native/logik_simulation/src/data/component/statefuls.rs
@@ -306,7 +306,7 @@ impl Component for Clock {
         }
     }
     
-    fn evaluate(&self, data: HashMap<usize, StateChange>) -> HashMap<usize, SubnetState> {
+    fn evaluate(&self, _: HashMap<usize, StateChange>) -> HashMap<usize, SubnetState> {
         let val = match self.state.get() {
             true => SubnetState::On,
             false => SubnetState::Off

--- a/native/logik_simulation/src/data/test/mod.rs
+++ b/native/logik_simulation/src/data/test/mod.rs
@@ -56,14 +56,16 @@ fn test_adding_components() {
     
     assert!(data.add_component(Box::new(OutputGate {}), vec![Some(0)]).is_ok());
     
-    assert_eq!(data.edges, map!(
-            3 => set!(edge!(0, 3, 0, 0)),
-            0 => set!(edge!(0, 3, 0, 0), edge!(0, 5, 2, 2), edge!(0, 7, 0, 0)),
-            5 => set!(edge!(0, 5, 2, 2), edge!(2, 5, 0, 0), edge!(10, 5, 1, 0)),
-            2 => set!(edge!(2, 5, 0, 0)),
-            10 => set!(edge!(10, 5, 1, 0)),
-            7 => set!(edge!(0, 7, 0, 0))
-        ));
+    assert_eq!(data.component_edges, map!(
+        1 => set!(edge!(0, 1, 0, 0)),
+        2 => set!(edge!(0, 2, 2, 2), edge!(1, 2, 0, 0), edge!(5, 2, 1, 0)),
+        3 => set!(edge!(0, 3, 0, 0))
+    ));
+    assert_eq!(data.subnet_edges, map!(
+        0 => set!(edge!(0, 1, 0, 0), edge!(0, 2, 2, 2), edge!(0, 3, 0, 0)),
+        1 => set!(edge!(1, 2, 0, 0)),
+        5 => set!(edge!(5, 2, 1, 0))
+    ));
     
     assert!(data.add_component(Box::new(AND {}), vec![]).is_err());
 }
@@ -75,22 +77,27 @@ fn test_removing_subnets() {
     data.add_subnet(0);
     data.add_subnet(1);
     
-    assert_eq!(data.edges, map!());
+    assert_eq!(data.component_edges, map!());
+    assert_eq!(data.subnet_edges, map!());
     
     assert!(data.add_component(Box::new(OutputGate {}), vec![Some(0)]).is_ok());
     
-    assert_eq!(data.edges, map!(
-            0 => set!(edge!(0, 3, 0, 0)),
-            3 => set!(edge!(0, 3, 0, 0))
-        ));
+    assert_eq!(data.component_edges, map!(
+        1 => set!(edge!(0, 1, 0, 0))
+    ));
+    assert_eq!(data.subnet_edges, map!(
+        0 => set!(edge!(0, 1, 0, 0))
+    ));
     
     assert!(data.remove_subnet(0));
     
-    assert_eq!(data.edges, map!());
+    assert_eq!(data.component_edges, map!());
+    assert_eq!(data.subnet_edges, map!());
     
     assert!(data.remove_subnet(1));
     
-    assert_eq!(data.edges, map!());
+    assert_eq!(data.component_edges, map!());
+    assert_eq!(data.subnet_edges, map!());
     
     assert!(!data.remove_subnet(0));
     assert!(!data.remove_subnet(3));

--- a/native/logik_simulation/src/ffi/test.rs
+++ b/native/logik_simulation/src/ffi/test.rs
@@ -2,12 +2,33 @@ use super::*;
 
 #[test]
 fn test_unlinking_unlinked() {
-    let mut data = init();
+    let data = init();
     
     assert!(add_subnet(data, 0));
     let comp = add_component(data, ComponentId::Buffer);
     
     assert!(!unlink(data, comp, 0, 0));
+    
+    exit(data);
+}
+
+#[test]
+fn test_removing_all_links() {
+    let data = init();
+    
+    assert!(add_subnet(data, 1));
+    assert!(add_subnet(data, 2));
+    assert!(add_subnet(data, 3));
+    
+    let id = add_component(data, ComponentId::And);
+    
+    assert!(link(data, id, 0, 1));
+    assert!(link(data, id, 1, 2));
+    assert!(link(data, id, 2, 3));
+    
+    assert!(unlink(data, id, 0, 1));
+    assert!(unlink(data, id, 1, 2));
+    assert!(unlink(data, id, 2, 3));
     
     exit(data);
 }


### PR DESCRIPTION
This PR changes how edges are stored. Before, all edges were stored in the same hashmap. Now, all edges associated with components are stored in one hashmap and all edges associated with subnets are stored in a different hashmap. Also solves a bug where the program would crash if every connection with a component is removed.

Should also resolve #50 due to #50 probably being caused by an error in how edges are accesed.