### PR TITLE
Backend for Pokeable Components

### DIFF
--- a/native/logik_simulation/src/data/component/components.rs
+++ b/native/logik_simulation/src/data/component/components.rs
@@ -21,6 +21,8 @@ impl Component for OutputGate {
     fn evaluate(&self, _: HashMap<usize, StateChange>) -> HashMap<usize, SubnetState> {
         map!()
     }
+
+
 }
 
 #[derive(Debug)]

--- a/native/logik_simulation/src/data/component/mod.rs
+++ b/native/logik_simulation/src/data/component/mod.rs
@@ -78,6 +78,7 @@ pub enum ComponentId {
     Input = 3,
     LED = 5,
     Button = 8,
+    Switch = 9,
     Buffer = 50,
     Not = 51,
     And = 52,

--- a/native/logik_simulation/src/data/component/mod.rs
+++ b/native/logik_simulation/src/data/component/mod.rs
@@ -19,6 +19,14 @@ pub(crate) trait Component: Debug {
             .map(|e| self.port_type(e).unwrap())
             .collect()
     }
+    fn pressed(&self) -> SubnetState{
+        return SubnetState::Error
+    }
+
+    fn released(&self) -> SubnetState{
+        return SubnetState::Error
+    }
+
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/native/logik_simulation/src/data/component/statefuls.rs
+++ b/native/logik_simulation/src/data/component/statefuls.rs
@@ -66,19 +66,21 @@ impl Component for Button {
         };
         map!(0 => val)
     }
+
+    fn pressed(&self) -> SubnetState{
+        self.state.set(true);
+        return SubnetState::On
+    }
+
+    fn released(&self) -> SubnetState {
+        self.state.set(false);
+        return SubnetState::Off
+    }
 }
 
 impl Button {
     pub(crate) fn new() -> Self {
         Self { state: Cell::new(false) }
-    }
-
-    pub(crate) fn toggle(&self){
-        if self.state.get() == true{
-            self.state.set(false);
-        }else if self.state.get() == false{
-            self.state.set(true);
-        }
     }
 }
 
@@ -109,19 +111,35 @@ impl Component for Switch {
         };
         map!(0 => val)
     }
+    fn pressed(&self) -> SubnetState{
+        match self.state.get(){
+            true => {
+                self.state.set(false);
+                return SubnetState::Off
+            }
+            false => {
+                self.state.set(true);
+                return SubnetState::On
+            }
+        }
+    }
+
+    fn released(&self) -> SubnetState {
+        match self.state.get(){
+            true => {
+                return SubnetState::On
+            }
+            false => {
+                self.state.set(true);
+                return SubnetState::Off
+            }
+        }
+    }
 }
 
 impl Switch {
     pub(crate) fn new() -> Self {
         Self { state: Cell::new(false) }
-    }
-
-    pub(crate) fn toggle(&self) {
-        if self.state.get() == true {
-            self.state.set(false);
-        } else if self.state.get() == false {
-            self.state.set(true);
-        }
     }
 }
 
@@ -170,19 +188,36 @@ impl Component for DFlipFlop {
             4 => vals.1
         )
     }
+
+    fn pressed(&self) -> SubnetState{
+        match self.state.get(){
+            true => {
+                self.state.set(false);
+                return SubnetState::Off
+            }
+            false => {
+                self.state.set(true);
+                return SubnetState::On
+            }
+        }
+    }
+
+    fn released(&self) -> SubnetState {
+        match self.state.get(){
+            true => {
+                return SubnetState::On
+            }
+            false => {
+                self.state.set(true);
+                return SubnetState::Off
+            }
+        }
+    }
 }
 
 impl DFlipFlop {
     pub(crate) fn new() -> Self {
         Self { state: Cell::new(false) }
-    }
-
-    pub(crate) fn toggle(&self){
-        if self.state.get() == true{
-            self.state.set(false);
-        }else if self.state.get() == false{
-            self.state.set(true);
-        }
     }
 }
 
@@ -228,6 +263,31 @@ impl Component for TFlipFlop {
             4 => vals.1
         )
     }
+
+    fn pressed(&self) -> SubnetState{
+        match self.state.get(){
+            true => {
+                self.state.set(false);
+                return SubnetState::Off
+            }
+            false => {
+                self.state.set(true);
+                return SubnetState::On
+            }
+        }
+    }
+
+    fn released(&self) -> SubnetState {
+        match self.state.get(){
+            true => {
+                return SubnetState::On
+            }
+            false => {
+                self.state.set(true);
+                return SubnetState::Off
+            }
+        }
+    }
 }
 
 impl TFlipFlop {
@@ -235,13 +295,6 @@ impl TFlipFlop {
         Self { state: Cell::new(false) }
     }
 
-    pub(crate) fn toggle(&self){
-        if self.state.get() == true{
-            self.state.set(false);
-        }else if self.state.get() == false{
-            self.state.set(true);
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -293,19 +346,36 @@ impl Component for JKFlipFlop {
             5 => vals.1
         )
     }
+
+    fn pressed(&self) -> SubnetState{
+        match self.state.get(){
+            true => {
+                self.state.set(false);
+                return SubnetState::Off
+            }
+            false => {
+                self.state.set(true);
+                return SubnetState::On
+            }
+        }
+    }
+
+    fn released(&self) -> SubnetState {
+        match self.state.get(){
+            true => {
+                return SubnetState::On
+            }
+            false => {
+                self.state.set(true);
+                return SubnetState::Off
+            }
+        }
+    }
 }
 
 impl JKFlipFlop {
     pub(crate) fn new() -> Self {
         Self { state: Cell::new(false) }
-    }
-
-    pub(crate) fn toggle(&self){
-        if self.state.get() == true{
-            self.state.set(false);
-        }else if self.state.get() == false{
-            self.state.set(true);
-        }
     }
 }
 
@@ -356,19 +426,36 @@ impl Component for SRFlipFlop {
             5 => vals.1
         )
     }
+
+    fn pressed(&self) -> SubnetState{
+        match self.state.get(){
+            true => {
+                self.state.set(false);
+                return SubnetState::Off
+            }
+            false => {
+                self.state.set(true);
+                return SubnetState::On
+            }
+        }
+    }
+
+    fn released(&self) -> SubnetState {
+        match self.state.get(){
+            true => {
+                return SubnetState::On
+            }
+            false => {
+                self.state.set(true);
+                return SubnetState::Off
+            }
+        }
+    }
 }
 
 impl SRFlipFlop {
     pub(crate) fn new() -> Self {
         Self { state: Cell::new(false) }
-    }
-
-    pub(crate) fn toggle(&self){
-        if self.state.get() == true{
-            self.state.set(false);
-        }else if self.state.get() == false{
-            self.state.set(true);
-        }
     }
 }
 

--- a/native/logik_simulation/src/data/component/statefuls.rs
+++ b/native/logik_simulation/src/data/component/statefuls.rs
@@ -72,6 +72,57 @@ impl Button {
     pub(crate) fn new() -> Self {
         Self { state: Cell::new(false) }
     }
+
+    pub(crate) fn toggle(&self){
+        if self.state.get() == true{
+            self.state.set(false);
+        }else if self.state.get() == false{
+            self.state.set(true);
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct Switch {
+    #[cfg(not(test))]
+    state: Cell<bool>,
+    #[cfg(test)]
+    pub state: Cell<bool>,
+}
+
+impl Component for Switch {
+    fn ports(&self) -> usize {
+        1
+    }
+
+    fn port_type(&self, port: usize) -> Option<PortType> {
+        match port {
+            0 => Some(PortType::Output),
+            _ => None,
+        }
+    }
+
+    fn evaluate(&self, _: HashMap<usize, StateChange>) -> HashMap<usize, SubnetState> {
+        let val = match self.state.get() {
+            true => SubnetState::On,
+            false => SubnetState::Off,
+        };
+        map!(0 => val)
+    }
+}
+
+impl Switch {
+    pub(crate) fn new() -> Self {
+        Self { state: Cell::new(false) }
+    }
+
+    pub(crate) fn toggle(&self) {
+        if self.state.get() == true {
+            self.state.set(false);
+        } else if self.state.get() == false {
+            self.state.set(true);
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -125,6 +176,14 @@ impl DFlipFlop {
     pub(crate) fn new() -> Self {
         Self { state: Cell::new(false) }
     }
+
+    pub(crate) fn toggle(&self){
+        if self.state.get() == true{
+            self.state.set(false);
+        }else if self.state.get() == false{
+            self.state.set(true);
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -174,6 +233,14 @@ impl Component for TFlipFlop {
 impl TFlipFlop {
     pub(crate) fn new() -> Self {
         Self { state: Cell::new(false) }
+    }
+
+    pub(crate) fn toggle(&self){
+        if self.state.get() == true{
+            self.state.set(false);
+        }else if self.state.get() == false{
+            self.state.set(true);
+        }
     }
 }
 
@@ -232,6 +299,14 @@ impl JKFlipFlop {
     pub(crate) fn new() -> Self {
         Self { state: Cell::new(false) }
     }
+
+    pub(crate) fn toggle(&self){
+        if self.state.get() == true{
+            self.state.set(false);
+        }else if self.state.get() == false{
+            self.state.set(true);
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -286,6 +361,14 @@ impl Component for SRFlipFlop {
 impl SRFlipFlop {
     pub(crate) fn new() -> Self {
         Self { state: Cell::new(false) }
+    }
+
+    pub(crate) fn toggle(&self){
+        if self.state.get() == true{
+            self.state.set(false);
+        }else if self.state.get() == false{
+            self.state.set(true);
+        }
     }
 }
 

--- a/native/logik_simulation/src/data/mod.rs
+++ b/native/logik_simulation/src/data/mod.rs
@@ -148,7 +148,26 @@ impl Data {
         
         true
     }
-    
+
+    pub(crate) fn press_component(&mut self, id: i32) -> SubnetState {
+        let state = self.components.get(&id).unwrap().pressed();
+
+        self.simulation.update_component(id, &self.components, &mut self.subnets, &self.component_edges);
+        self.simulation.process_until_clean(&self.components, &mut self.subnets, &self.subnet_edges, &self.component_edges);
+
+        return state
+    }
+
+    pub(crate) fn release_component(&mut self, id: i32) -> SubnetState {
+        let state = self.components.get(&id).unwrap().released();
+
+        self.simulation.update_component(id, &self.components, &mut self.subnets, &self.component_edges);
+        self.simulation.process_until_clean(&self.components, &mut self.subnets, &self.subnet_edges, &self.component_edges);
+
+        return state
+
+    }
+
     fn add_edge(&mut self, subnet: i32, component: i32, port: usize, direction: EdgeDirection) {
         let edge = Edge::new(subnet, component, port, direction);
     

--- a/native/logik_simulation/src/ffi/mod.rs
+++ b/native/logik_simulation/src/ffi/mod.rs
@@ -42,6 +42,7 @@ pub extern "C" fn add_component(data: *mut Data, component: ComponentId) -> i32 
         ComponentId::Input => Box::new(InputGate {}),
         ComponentId::LED => Box::new(LED {}),
         ComponentId::Button => Box::new(Button::new()),
+        ComponentId::Switch => Box::new(Switch::new()),
         ComponentId::Buffer => Box::new(Buffer {}),
         ComponentId::Not => Box::new(NOT {}),
         ComponentId::And => Box::new(AND {}),

--- a/native/logik_simulation/src/ffi/mod.rs
+++ b/native/logik_simulation/src/ffi/mod.rs
@@ -116,3 +116,16 @@ pub extern "C" fn port_state(data: *mut Data, component: i32, port: i32) -> Subn
         None => SubnetState::Floating,
 	}
 }
+
+#[no_mangle]
+pub extern "C" fn press_component(data: *mut Data, id: i32) -> SubnetState {
+    let data = unsafe { &mut *data };
+
+   data.press_component(id)
+}
+
+pub extern "C" fn release_component(data: *mut Data, id: i32) -> SubnetState {
+    let data = unsafe { &mut *data };
+
+    data.release_component(id)
+}


### PR DESCRIPTION
kan för lite om C# och frontenden för pokeable components, men här är backenden. den bygger på press och release funktioner, vilket gör att man kan hålla in en knapp till exempel. 
Något att vara försiktig med dock är att se till att man får med alla möjliga fall av component_released, då det finns fler sätt att tappa fokus än att släppa vänsterknappen.
